### PR TITLE
fix documentation and "moved" attribute

### DIFF
--- a/TootNet/Internal/Converter.cs
+++ b/TootNet/Internal/Converter.cs
@@ -68,7 +68,7 @@ namespace TootNet.Internal
                 throw new MastodonException(error);
             }
 
-            return JToken.Parse(json).ToObject<T>();
+            return parsed.ToObject<T>();
         }
 
         public static void ConvertError(string json)

--- a/TootNet/Objects/Account.cs
+++ b/TootNet/Objects/Account.cs
@@ -57,7 +57,7 @@ namespace TootNet.Objects
         public IEnumerable<Emoji> Emojis { get; set; }
 
         [JsonProperty("moved")]
-        public string Moved { get; set; }
+        public Account Moved { get; set; }
 
         [JsonProperty("fields")]
         public IEnumerable<Field> Fields { get; set; }

--- a/TootNet/Rest/Accounts.cs
+++ b/TootNet/Rest/Accounts.cs
@@ -44,7 +44,7 @@ namespace TootNet.Rest
         /// <summary>
         /// <para>Returns a representation of the requesting user if authentication was successful.</para>
         /// <para>Available parameters:</para>
-        /// <para>- <c>long</c> id (required)</para>
+        /// <para>- No parameters available in this method.</para>
         /// </summary>
         /// <param name="parameters">The parameters.</param>
         /// <returns>


### PR DESCRIPTION
- fix documentation
- fix `moved` attribute in `Account` class
The type of `moved` attribute is not `string` but `Account`.
https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#account
